### PR TITLE
[XML Parser] Don't modify libxml2's predefined entity structs

### DIFF
--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1224,7 +1224,6 @@ static xmlEntityPtr getEntityHandler(void* closure, const xmlChar* name)
 
     xmlEntityPtr ent = xmlGetPredefinedEntity(name);
     if (ent) {
-        ent->etype = XML_INTERNAL_PREDEFINED_ENTITY;
         return ent;
     }
 


### PR DESCRIPTION
These structs will be made const at some point and there's no need to set the `etype` member which is already set to `XML_INTERNAL_PREDEFINED_ENTITY` for predefined entities. Also see https://issues.chromium.org/issues/343953488